### PR TITLE
Add Renovate dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,3 +81,7 @@ Simply open [Lovable](https://lovable.dev/projects/35d72d2e-6e25-40e5-9b0c-c0d1a
 ## I want to use a custom domain - is that possible?
 
 We don't support custom domains (yet). If you want to deploy your project under your own domain then we recommend using Netlify. Visit our docs for more details: [Custom domains](https://docs.lovable.dev/tips-tricks/custom-domain/)
+
+## Dependency maintenance with Renovate
+
+This project uses [Renovate](https://github.com/renovatebot/renovate) to keep dependencies up to date. Run `npm run renovate` to check for updates.

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "build:dev": "vite build --mode development",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "renovate": "renovate"
   },
   "dependencies": {
     "@clerk/clerk-react": "^5.31.5",
@@ -88,6 +89,7 @@
     "tailwindcss": "^3.4.11",
     "typescript": "^5.5.3",
     "typescript-eslint": "^8.0.1",
-    "vite": "^5.4.1"
+    "vite": "^5.4.1",
+    "renovate": "^37.0.0"
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,3 @@
+{
+  "extends": ["config:base"]
+}


### PR DESCRIPTION
## Summary
- add Renovate CLI script in package.json
- add Renovate dev dependency
- add minimal `renovate.json`
- document usage of Renovate in README

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*